### PR TITLE
Updated constant expression handler for booleans

### DIFF
--- a/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/ConstantExpressionEvaluator.cs
+++ b/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/ConstantExpressionEvaluator.cs
@@ -28,7 +28,10 @@
             }
             else if (value != null && (_binaryExpression.NodeType == ExpressionType.Equal))
             {
-                if (value is string && !value.ToString().StartsWith("\""))
+                if(value is bool)
+                {
+                    value = $"{value.ToString().ToLower()}";
+                }else if(value is string && !value.ToString().StartsWith("\""))
                 {
                     value = $"'{value}'";
                 }


### PR DESCRIPTION
I found a bug when using the WhereClause Selector with a boolean property the gremlin string produced was not correct.

give a query on the GraphClient like `client.From<Expert>().Where(e => e.Active == true).SubmitAsync();` the constant expression handler would produce a gremlin query that is `g.V().has('label','Expert').has('Active', True)` and the gremlin query should be `g.V().has('label','Expert').has('Active', true)`

Adding a check for the value being a boolean and using the ToLower will solve this problem.