### PR TITLE
Allow overriding propertynames and support json.net attributes

### DIFF
--- a/Gremlin.Linq.Tests/QueryTests.cs
+++ b/Gremlin.Linq.Tests/QueryTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Gremlin.Linq.Tests
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Gremlin.Linq.Tests
 {
     using System;
     using Entities;
@@ -178,6 +180,54 @@
                 .Where(a => a.FirstName.Equals("kalle") && (a.LastName == "Sven" || a.Age > 3))
                 .BuildGremlinQuery();
             Assert.AreEqual("g.V().has('label','User').has('FirstName', 'kalle').has('LastName', 'Sven').has('Age', gt(3))", q);
+        }
+
+        [TestMethod]
+        public void TestJsonPropertyNameOverrideWhere()
+        {
+            IGraphClient client = new TestGraphClient();
+            var q = client
+                .From<User>()
+                .Where(x => x.TestJsonPropertyName == "a")
+                .BuildGremlinQuery();
+            Assert.AreEqual("g.V().has('label','User').has('NameOverride', 'a')", q);
+        }
+
+        [TestMethod]
+        public void TestJsonPropertyNameOverrideSet()
+        {
+            IGraphClient client = new TestGraphClient();
+            var q = client
+                .Add(new User
+                {
+                    Age = 10,
+                    FirstName = "name",
+                    TestJsonPropertyName = "a"
+                })
+                .BuildGremlinQuery();
+            Assert.AreEqual("g.addV('User').property('FirstName', 'name').property('Age', 10).property('NameOverride', 'a')", q);
+        }
+
+        [TestMethod]
+        public void TestCustomLabelForUser()
+        {
+            IGraphClient client = new TestGraphClient();
+            var q = client
+                .From<UserWithCustomLabel>()
+                .Where(a => a.Name == "name")
+                .BuildGremlinQuery();
+            Assert.AreEqual("g.V().has('label','CustomUser').has('Name', 'name')", q);
+        }
+
+        [TestMethod]
+        public void TestCustomJsonNetLabelForUser()
+        {
+            IGraphClient client = new TestGraphClient();
+            var q = client
+                .From<UserWithCustomLabelUsingJsonNet>()
+                .Where(a => a.Name == "name")
+                .BuildGremlinQuery();
+            Assert.AreEqual("g.V().has('label','JsonNetUser').has('Name', 'name')", q);
         }
     }
 }

--- a/Gremlin.Linq.Tests/User.cs
+++ b/Gremlin.Linq.Tests/User.cs
@@ -1,4 +1,6 @@
-﻿namespace Gremlin.Linq.Entities
+﻿using Newtonsoft.Json;
+
+namespace Gremlin.Linq.Entities
 {
     using System.Collections.Generic;
 
@@ -11,5 +13,8 @@
         public string SubjectId { get; set; }
         public string Username { get; set; }
         public int Age { get; set; }
+        
+        [JsonProperty("NameOverride")]
+        public string TestJsonPropertyName { get; set; }
     }
 }

--- a/Gremlin.Linq.Tests/UserWithCustomLabel.cs
+++ b/Gremlin.Linq.Tests/UserWithCustomLabel.cs
@@ -1,0 +1,8 @@
+﻿namespace Gremlin.Linq.Entities
+{
+    [GremlinLabel("CustomUser")]
+    public class UserWithCustomLabel : Vertex
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Gremlin.Linq.Tests/UserWithCustomLabelUsingJsonNet.cs
+++ b/Gremlin.Linq.Tests/UserWithCustomLabelUsingJsonNet.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Gremlin.Linq.Entities
+{
+    [JsonObject("JsonNetUser")]
+    public class UserWithCustomLabelUsingJsonNet : Vertex
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Gremlin.Linq/GremlinGraphClient.cs
+++ b/Gremlin.Linq/GremlinGraphClient.cs
@@ -151,7 +151,7 @@
             var properties = (IDictionary<string, object>) propertiesObj;
             foreach (var propertyInfo in entityProperties)
             {
-                if (!properties.TryGetValue(propertyInfo.Name, out dynamic value))
+                if (!properties.TryGetValue(propertyInfo.GetPropertyName(), out dynamic value))
                 {
                     continue;
                 }

--- a/Gremlin.Linq/GremlinProperty.cs
+++ b/Gremlin.Linq/GremlinProperty.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Gremlin.Linq
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class GremlinPropertyAttribute : Attribute
+    {
+        public string Name { get; }
+
+        public GremlinPropertyAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/Gremlin.Linq/Linq/Commands/InsertCommand.cs
+++ b/Gremlin.Linq/Linq/Commands/InsertCommand.cs
@@ -90,7 +90,7 @@
                 return string.Empty;
             }
 
-            return propertyInfo.Name.BuildGremlinQueryForValue(value);
+            return propertyInfo.GetPropertyName().BuildGremlinQueryForValue(value);
         }
         public static string BuildGremlinQueryForValue(this string propertyInfo, object value)
             {

--- a/Gremlin.Linq/Linq/Commands/SetCommand.cs
+++ b/Gremlin.Linq/Linq/Commands/SetCommand.cs
@@ -12,7 +12,7 @@ namespace Gremlin.Linq.Linq.Commands
 
         public IGremlinQueryable ParentSelector { get; set; }
 
-        internal SetCommand(IGraphClient client, string property,object value) : base(client)
+        internal SetCommand(IGraphClient client, string property, object value) : base(client)
         {
             _property = property;
             _value = value;
@@ -26,7 +26,7 @@ namespace Gremlin.Linq.Linq.Commands
     public class SetCommand<T> : SetCommand
     {
 
-        public SetCommand(IGraphClient client, PropertyInfo property, object value) : base(client, property.Name,value)
+        public SetCommand(IGraphClient client, PropertyInfo property, object value) : base(client, property.GetPropertyName(), value)
         {
         }
         

--- a/Gremlin.Linq/Linq/PropertyInfoExtensions.cs
+++ b/Gremlin.Linq/Linq/PropertyInfoExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Gremlin.Linq
+{
+    public static class PropertyInfoExtensions
+    {
+        public static string GetPropertyName(this PropertyInfo element)
+        {
+            return element.GetCustomAttribute<GremlinPropertyAttribute>()?.Name ??
+                   element.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName ??
+                   element.Name;
+        }
+
+        public static string GetPropertyName(this MemberInfo element)
+        {
+            return element.GetCustomAttribute<GremlinPropertyAttribute>()?.Name ??
+                   element.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName ??
+                   element.Name;
+        }
+    }
+}

--- a/Gremlin.Linq/Linq/Selectors/ConnectedVertexSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/ConnectedVertexSelector.cs
@@ -11,7 +11,7 @@
 
         public override string BuildGremlinQuery()
         {
-            return ParentSelector.BuildGremlinQuery() + $".out('{_relation}').hasLabel('{typeof(T).Name}')";
+            return ParentSelector.BuildGremlinQuery() + $".out('{_relation}').hasLabel('{typeof(T).GetLabel()}')";
         }
     }
 }

--- a/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/ConstantExpressionEvaluator.cs
+++ b/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/ConstantExpressionEvaluator.cs
@@ -42,7 +42,7 @@
                 throw new ArgumentException($"Unsupported nodetype {_binaryExpression.NodeType}");
             }
 
-            return $".has('{((MemberExpression) _binaryExpression.Left).Member.Name}', {value})";
+            return $".has('{((MemberExpression) _binaryExpression.Left).Member.GetPropertyName()}', {value})";
         }
     }
 }

--- a/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/MemberExpressionEvaluator.cs
+++ b/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/MemberExpressionEvaluator.cs
@@ -18,7 +18,7 @@ namespace Gremlin.Linq.Linq.Selectors.ExpressionHandlers
         {            
             var expression = Evaluator.PartialEval(_binaryExpression.Right as MemberExpression);
             var value = expression.ToString();            
-            return $".has('{(_binaryExpression.Left as MemberExpression)?.Member.Name}', '{value.Replace("\"", "")}')";
+            return $".has('{(_binaryExpression.Left as MemberExpression)?.Member.GetPropertyName()}', '{value.Replace("\"", "")}')";
         }
     }
 }

--- a/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/MethodCallExpressionEvaluator.cs
+++ b/Gremlin.Linq/Linq/Selectors/ExpressionHandlers/MethodCallExpressionEvaluator.cs
@@ -14,7 +14,7 @@
         }
         public string Evaluate()
         {
-            var memberName = (_expression.Object as MemberExpression)?.Member.Name;
+            var memberName = (_expression.Object as MemberExpression)?.Member.GetPropertyName();
             var value = _expression.Arguments.First();
             return $".has('{memberName}', '{value.ToString().Replace("\"","")}')";
         }

--- a/Gremlin.Linq/Linq/Selectors/FromSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/FromSelector.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Linq.Expressions;
-    using System.Reflection;
 
     public class FromSelector<TEntity> : Selector<TEntity>, ICountable, IWhereSelector<TEntity>
     {
@@ -47,19 +46,5 @@
             return whereSelector;
         }
         
-    }
-
-    public static class TypeExtensions
-    {
-        public static string GetLabel(this Type t)
-        {
-            var labelAttribute = t.GetCustomAttribute<GremlinLabelAttribute>();
-            if (labelAttribute != null)
-            {
-                return labelAttribute.Label;
-            }
-
-            return t.Name;            
-        }
     }
 }

--- a/Gremlin.Linq/Linq/Selectors/InEdgeSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/InEdgeSelector.cs
@@ -23,7 +23,7 @@
 
         public override string BuildGremlinQuery()
         {
-            var result = ParentSelector.BuildGremlinQuery() + $".inE().has('label','{typeof(TEntity).Name}')";
+            var result = ParentSelector.BuildGremlinQuery() + $".inE().has('label','{typeof(TEntity).GetLabel()}')";
             if (!string.IsNullOrEmpty(_alias))
             {
                 result = result + $".as('{_alias}')";

--- a/Gremlin.Linq/Linq/Selectors/InSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/InSelector.cs
@@ -8,7 +8,7 @@
 
         public override string BuildGremlinQuery()
         {
-            return ParentSelector.BuildGremlinQuery() + $".in().has('label','{typeof(T).Name}')";
+            return ParentSelector.BuildGremlinQuery() + $".in().has('label','{typeof(T).GetLabel()}')";
         }
     }
 }

--- a/Gremlin.Linq/Linq/Selectors/InVertexSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/InVertexSelector.cs
@@ -21,7 +21,7 @@
 
         public override string BuildGremlinQuery()
         {
-            var result = ParentSelector.BuildGremlinQuery() + $".inV().has('label','{typeof(TEntity).Name}')";
+            var result = ParentSelector.BuildGremlinQuery() + $".inV().has('label','{typeof(TEntity).GetLabel()}')";
             if (!string.IsNullOrEmpty(_alias))
             {
                 result = result + $".as('{_alias}')";

--- a/Gremlin.Linq/Linq/Selectors/OutSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/OutSelector.cs
@@ -15,13 +15,13 @@
         }
         public OutSelector<TEntity> As<T>()
         {
-            _alias = typeof(T).Name;
+            _alias = typeof(T).GetLabel();
             return this;
         }
 
         public override string BuildGremlinQuery()
         {
-            var result= ParentSelector.BuildGremlinQuery() + $".out().has('label','{typeof(TEntity).Name}')";
+            var result = ParentSelector.BuildGremlinQuery() + $".out().has('label','{typeof(TEntity).GetLabel()}')";
             if (!string.IsNullOrEmpty(_alias))
             {
                 result = result + $".as('{_alias}')";

--- a/Gremlin.Linq/Linq/Selectors/OutVertexSelector.cs
+++ b/Gremlin.Linq/Linq/Selectors/OutVertexSelector.cs
@@ -15,13 +15,13 @@
         }
         public OutVertexSelector<TEntity> As<T>()
         {
-            _alias = typeof(T).Name;
+            _alias = typeof(T).GetLabel();
             return this;
         }
 
         public override string BuildGremlinQuery()
         {
-            var result = ParentSelector.BuildGremlinQuery() + $".outV().has('label','{typeof(TEntity).Name}')";
+            var result = ParentSelector.BuildGremlinQuery() + $".outV().has('label','{typeof(TEntity).GetLabel()}')";
             if (!string.IsNullOrEmpty(_alias))
             {
                 result = result + $".as('{_alias}')";

--- a/Gremlin.Linq/Linq/TypeExtensions.cs
+++ b/Gremlin.Linq/Linq/TypeExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Gremlin.Linq.Linq
+{
+    public static class TypeExtensions
+    {
+        public static string GetLabel(this Type type)
+        {
+            return type.GetCustomAttribute<GremlinLabelAttribute>()?.Label ??
+                   type.GetCustomAttribute<JsonObjectAttribute>()?.Id ??
+                   type.Name;  
+        }
+    }
+}


### PR DESCRIPTION
  * Added support for setting property names in JsonProperty and GremlinProperty using PropertyInfoExtensions.
  * Fixed so that it uses .GetLabel() on types instead of .Name on all type references, and added support for setting label from JsonObjectAttribute.
  * Moved TypeExtensions to a separate file.
  * Added tests
