### PR TITLE
Update Gremlin.Net version and fix custom vertex labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,5 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+**/appsettings.Development.json

--- a/Gremlin.Linq.TestApp/Gremlin.Linq.TestApp.csproj
+++ b/Gremlin.Linq.TestApp/Gremlin.Linq.TestApp.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Gremlin.Linq.TestApp/Program.cs
+++ b/Gremlin.Linq.TestApp/Program.cs
@@ -1,34 +1,36 @@
 ﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Gremlin.Linq.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Gremlin.Linq.TestApp
 {
-    using Linq;
-    using Microsoft.Extensions.Configuration;
-    using System.Linq;
-    using System.Threading.Tasks;
-
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             MainAsync(args).GetAwaiter().GetResult();
             Console.ReadLine();
         }
-        static async Task MainAsync(string[] args) { 
-        var config = new ConfigurationBuilder()
+
+        private static async Task MainAsync(string[] args)
+        {
+            var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.Development.json", false)
                 .Build();
             var settings = new GraphClientSettings(config);
-            var client = new GremlinGraphClient(settings.Url,settings.Database,settings.Collection,settings.Password)
-                {
-                    Logger = new GremlinLogger()
-                }; 
+            var client = new GremlinGraphClient(settings.Url, settings.Database, settings.Collection, settings.Password)
+            {
+                Logger = new GremlinLogger()
+            };
 
             var users = await client.From<User>().SubmitAsync();
             Console.WriteLine(users.Count());
 
             var user = await client
-                .Add(new User()
+                .Add(new User
                 {
                     Name = "John Doe"
                 })
@@ -41,6 +43,6 @@ namespace Gremlin.Linq.TestApp
 
     public class User : Vertex
     {
-        public string Name { get; set; }        
+        public string Name { get; set; }
     }
 }

--- a/Gremlin.Linq.TestApp/Program.cs
+++ b/Gremlin.Linq.TestApp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Gremlin.Linq.Linq;
 using Microsoft.Extensions.Configuration;
@@ -26,23 +25,40 @@ namespace Gremlin.Linq.TestApp
                 Logger = new GremlinLogger()
             };
 
-            var users = await client.From<User>().SubmitAsync();
-            Console.WriteLine(users.Count());
-
-            var user = await client
+            await client
                 .Add(new User
                 {
-                    Name = "John Doe"
+                    FirstName = "John",
+                    LastName = "Doe",
+                    Age = 31
+                })
+                .SubmitAsync();
+            await client
+                .Add(new MyClass
+                {
+                    FavoriteColor = "Blue"
                 })
                 .SubmitAsync();
 
-            users = await client.From<User>().SubmitAsync();
-            Console.WriteLine(users.Count());
+            var users = await client.From<User>().SubmitAsync();
+            foreach (var user in users)
+                Console.WriteLine($"{user.Entity.FirstName} {user.Entity.LastName}, Age = {user.Entity.Age}");
         }
     }
 
+    [GremlinLabel("u")]
     public class User : Vertex
     {
-        public string Name { get; set; }
+        [GremlinProperty("first-name")] public string FirstName { get; set; }
+
+        [GremlinProperty("last-name")] public string LastName { get; set; }
+        public int Age { get; set; }
     }
+
+    
+    [GremlinLabel("my-custom-name")]
+    public class MyClass {
+        public string FavoriteColor {get; set; }
+    }
+
 }

--- a/Gremlin.Linq.Tests/Gremlin.Linq.Tests.csproj
+++ b/Gremlin.Linq.Tests/Gremlin.Linq.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <StartupObject></StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Gremlin.Linq.Tests/GremlinLabelAttributeTest.cs
+++ b/Gremlin.Linq.Tests/GremlinLabelAttributeTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gremlin.Linq.Tests
+{
+    [TestClass]
+    public class GremlinLabelAttributeTest
+    {
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Label_Is_Null()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinLabelAttribute(null));
+        }
+
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Label_Is_Empty()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinLabelAttribute(string.Empty));
+        }
+
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Label_Is_Whitespace()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinLabelAttribute(" "));
+        }
+    }
+}

--- a/Gremlin.Linq.Tests/GremlinPropertyAttributeTest.cs
+++ b/Gremlin.Linq.Tests/GremlinPropertyAttributeTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Gremlin.Linq.Tests
+{
+    [TestClass]
+    public class GremlinPropertyAttributeTest
+    {
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Name_Is_Null()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinPropertyAttribute(null));
+        }
+
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Name_Is_Empty()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinPropertyAttribute(string.Empty));
+        }
+
+        [TestMethod]
+        public void Ctor_Throws_ArgumentException_When_Name_Is_Whitespace()
+        {
+            // Arrange
+
+            // Assert
+
+            // Act
+            Assert.ThrowsException<ArgumentException>(() => new GremlinPropertyAttribute(" "));
+        }
+    }
+}

--- a/Gremlin.Linq/Gremlin.Linq.csproj
+++ b/Gremlin.Linq/Gremlin.Linq.csproj
@@ -21,9 +21,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gremlin.Net" Version="3.3.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageReference Include="Gremlin.Net" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Gremlin.Linq/GremlinGraphClient.cs
+++ b/Gremlin.Linq/GremlinGraphClient.cs
@@ -1,4 +1,6 @@
-﻿namespace Gremlin.Linq
+﻿using System.Reflection;
+
+namespace Gremlin.Linq
 {
     using System;
     using System.Collections.Generic;
@@ -151,7 +153,10 @@
             var properties = (IDictionary<string, object>) propertiesObj;
             foreach (var propertyInfo in entityProperties)
             {
-                if (!properties.TryGetValue(propertyInfo.Name, out dynamic value))
+                var propertyName = propertyInfo.Name;
+                if (propertyInfo.GetCustomAttributes(typeof(GremlinPropertyAttribute)).SingleOrDefault() is
+                    GremlinPropertyAttribute propertyAttribute) propertyName = propertyAttribute.Name;
+                if (!properties.TryGetValue(propertyName, out dynamic value))
                 {
                     continue;
                 }

--- a/Gremlin.Linq/GremlinLabelAttribute.cs
+++ b/Gremlin.Linq/GremlinLabelAttribute.cs
@@ -1,17 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Gremlin.Linq
 {
     [AttributeUsage(AttributeTargets.Class)]
     public class GremlinLabelAttribute : Attribute
     {
-        public string Label { get; }
-
         public GremlinLabelAttribute(string label)
         {
+            if (string.IsNullOrWhiteSpace(label))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(label));
             Label = label;
         }
+
+        public string Label { get; }
     }
 }

--- a/Gremlin.Linq/GremlinPropertyAttribute.cs
+++ b/Gremlin.Linq/GremlinPropertyAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Gremlin.Linq
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class GremlinPropertyAttribute : Attribute
+    {
+        public GremlinPropertyAttribute(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/Gremlin.Linq/Linq/Commands/InsertCommand.cs
+++ b/Gremlin.Linq/Linq/Commands/InsertCommand.cs
@@ -22,7 +22,7 @@
         {
             var result = new StringBuilder();
             result.Append(ParentCommand == null ? "g" : ParentCommand.BuildGremlinQuery());
-            result.Append($".addV('{_entity.GetType().Name}')");
+            result.Append($".addV('{_entity.GetType().GetLabel()}')");
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {
@@ -60,7 +60,7 @@
                 result.Append(ParentCommand.BuildGremlinQuery());
             }
 
-            result.Append($".addV('{_entity.GetType().Name}')");
+            result.Append($".addV('{_entity.GetType().GetLabel()}')");
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {

--- a/Gremlin.Linq/Linq/Commands/InsertCommand.cs
+++ b/Gremlin.Linq/Linq/Commands/InsertCommand.cs
@@ -1,12 +1,13 @@
-﻿namespace Gremlin.Linq.Linq
-{
-    using System;
-    using System.Collections;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Text;
-    using Newtonsoft.Json;
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Newtonsoft.Json;
 
+namespace Gremlin.Linq.Linq
+{
     public class InsertCommand : Command
     {
         private readonly object _entity;
@@ -26,11 +27,8 @@
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {
-                string gremlinCode = propertyInfo.BuildGremlinQuery(_entity);
-                if (!string.IsNullOrEmpty(gremlinCode))
-                {
-                    result.Append(gremlinCode);
-                }
+                var gremlinCode = propertyInfo.BuildGremlinQuery(_entity);
+                if (!string.IsNullOrEmpty(gremlinCode)) result.Append(gremlinCode);
             }
 
             return result.ToString();
@@ -51,24 +49,14 @@
         public override string BuildGremlinQuery()
         {
             var result = new StringBuilder();
-            if (ParentCommand == null)
-            {
-                result.Append("g");
-            }
-            else
-            {
-                result.Append(ParentCommand.BuildGremlinQuery());
-            }
+            result.Append(ParentCommand == null ? "g" : ParentCommand.BuildGremlinQuery());
 
             result.Append($".addV('{_entity.GetType().GetLabel()}')");
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {
                 var gremlinQuery = propertyInfo.BuildGremlinQuery(_entity);
-                if (!string.IsNullOrEmpty(gremlinQuery))
-                {
-                    result.Append(gremlinQuery);
-                }
+                if (!string.IsNullOrEmpty(gremlinQuery)) result.Append(gremlinQuery);
             }
 
             return result.ToString();
@@ -79,64 +67,44 @@
     {
         public static string BuildGremlinQuery(this PropertyInfo propertyInfo, object entity)
         {
-
-            if (propertyInfo.GetCustomAttribute<IgnoreAttribute>() != null)
-            {
-                return null;
-            }
+            if (propertyInfo.GetCustomAttribute<IgnoreAttribute>() != null) return null;
             var value = propertyInfo.GetGetMethod().Invoke(entity, new object[0]);
-            if (value == null)
-            {
-                return string.Empty;
-            }
+            if (value == null) return string.Empty;
 
-            return propertyInfo.Name.BuildGremlinQueryForValue(value);
+            var propertyName = propertyInfo.Name;
+            if (propertyInfo.GetCustomAttributes(typeof(GremlinPropertyAttribute)).SingleOrDefault() is
+                GremlinPropertyAttribute propertyAttribute) propertyName = propertyAttribute.Name;
+            return propertyName.BuildGremlinQueryForValue(value);
         }
-        public static string BuildGremlinQueryForValue(this string propertyInfo, object value)
+
+        public static string BuildGremlinQueryForValue(this string propertyName, object value)
+        {
+            if (value is DateTime time)
             {
-                if (value is DateTime)
-            {
-                var val = ((DateTime)value).ToString("s");
-                return $".property('{propertyInfo}', '{val}')";
+                var val = time.ToString("s");
+                return $".property('{propertyName}', '{val}')";
             }
 
             if (value is double || value is float)
             {
                 var val = (double) value;
-                return $".property('{propertyInfo}', {val.ToString(CultureInfo.GetCultureInfo("en-US"))})";
-            }
-            
-            if (value.GetType().IsEnum)
-            {
-                return $".property('{propertyInfo}', {(int)value})";
+                return $".property('{propertyName}', {val.ToString(CultureInfo.GetCultureInfo("en-US"))})";
             }
 
-            if (value is bool boolValue)
-            {
-                return $".property('{propertyInfo}', {boolValue.ToString().ToLower()})";
-            }
+            if (value.GetType().IsEnum) return $".property('{propertyName}', {(int) value})";
 
-            if (value.GetType().IsPrimitive)
-            {
-                return $".property('{propertyInfo}', {value})";
-            }
+            if (value is bool boolValue) return $".property('{propertyName}', {boolValue.ToString().ToLower()})";
 
-            if (value is string)
-            {
-                return $".property('{propertyInfo}', '{(value as string).Replace("\"", "")}')";
-            }
+            if (value.GetType().IsPrimitive) return $".property('{propertyName}', {value})";
 
-            if (value is IEnumerable)
-            {
-                return $".property('{propertyInfo}', '{JsonConvert.SerializeObject(value)}')";
-            }
+            if (value is string s) return $".property('{propertyName}', '{s.Replace("\"", "")}')";
+
+            if (value is IEnumerable) return $".property('{propertyName}', '{JsonConvert.SerializeObject(value)}')";
 
             if (value.GetType().IsClass || value.GetType().IsInterface)
-            {
-                return $".property('{propertyInfo}', '{JsonConvert.SerializeObject(value)}')";
-            }
+                return $".property('{propertyName}', '{JsonConvert.SerializeObject(value)}')";
 
-            return $".property('{propertyInfo}', '{value}')";
+            return $".property('{propertyName}', '{value}')";
         }
     }
 }

--- a/Gremlin.Linq/Linq/Commands/UpdateCommand.cs
+++ b/Gremlin.Linq/Linq/Commands/UpdateCommand.cs
@@ -1,12 +1,7 @@
-﻿namespace Gremlin.Linq.Linq
-{
-    using System;
-    using System.Collections;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Text;
-    using Newtonsoft.Json;
+﻿using System.Text;
 
+namespace Gremlin.Linq.Linq
+{
     public class UpdateCommand : Command
     {
         private readonly object _entity;
@@ -25,11 +20,8 @@
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {
-                string gremlinCode = propertyInfo.BuildGremlinQuery(_entity);
-                if (!string.IsNullOrEmpty(gremlinCode))
-                {
-                    result.Append(gremlinCode);
-                }
+                var gremlinCode = propertyInfo.BuildGremlinQuery(_entity);
+                if (!string.IsNullOrEmpty(gremlinCode)) result.Append(gremlinCode);
             }
 
             return result.ToString();
@@ -52,30 +44,20 @@
         {
             var result = new StringBuilder();
             if (ParentSelector != null)
-            {
                 result.Append(ParentSelector.BuildGremlinQuery());
-            }
             else if (ParentCommand != null)
-            {
                 result.Append(ParentCommand.BuildGremlinQuery());
-            }
             else
-            {
                 result.Append("g");
-            }
 
             var propertyInfos = _entity.GetType().GetProperties();
             foreach (var propertyInfo in propertyInfos)
             {
                 var gremlinQuery = propertyInfo.BuildGremlinQuery(_entity);
-                if (!string.IsNullOrEmpty(gremlinQuery))
-                {
-                    result.Append(gremlinQuery);
-                }
+                if (!string.IsNullOrEmpty(gremlinQuery)) result.Append(gremlinQuery);
             }
 
             return result.ToString();
         }
     }
-    
 }

--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,13 @@ Your appsettings.json should then look like this.
   "gremlin": {
     "url": "yourdb.azure.com",
     "database": "<databaseName>",
-    "collection": "<collectionName>"
+    "collection": "<collectionName>",
+	"password": "<access key>"
   }
 }
 ```
 
-Adding entities at it's simplest 
+Adding entities at its simplest 
 
 ```
 var user = client

--- a/readme.md
+++ b/readme.md
@@ -101,3 +101,24 @@ var courses = await _graphClient
 		.Set("LoginCount",3)
                 .SubmitAsync();            
 ```
+
+
+##Custom vertex properties
+
+To change the label for your vertices, you can specify the `GremlinLabel` attribute to your model class.
+
+```
+[GremlinLabel("my-vertex")]
+public class MyClass {
+	public string FavoriteColor {get; set; }
+}
+```
+
+To use a specific property name, you can specify the `GremlinProperty` attribute to your model class properties.
+
+```
+public class MyClass {
+	[GremlinProperty("fav-clr")]
+	public string FavoriteColor {get; set; }
+}
+```


### PR DESCRIPTION
I was unable to use gremlin.linq with a dotnet core 2.2 app and Gremlin.Net 3.4.  Rather than downgrading the Gremlin.Net to 3.3.2, I nudged the version forward.

In addition, I updated the two consuming projects (TestApp, Tests) to dotnet core 2.2.